### PR TITLE
New - Supports using third-party functions in compliance tests.

### DIFF
--- a/tools/jmespathnet.compliance/AssemblyQualifiedNameParser.cs
+++ b/tools/jmespathnet.compliance/AssemblyQualifiedNameParser.cs
@@ -1,0 +1,29 @@
+﻿using System.Reflection;
+using System.Text.RegularExpressions;
+
+namespace jmespath.net.compliance
+{
+    public sealed class AssemblyQualifiedNameParser
+    {
+        // no sane way to parse an assembly qualified name
+        // https://stackoverflow.com/questions/1410312/parsing-assembly-qualified-name
+
+        private const string Pattern = @"^(?<type>.*?),\ ?(?<assembly>[^,]+(?:,\ ?Version=[^,]+)?(?:,\ ?Culture=[^,]+)?(?:,\ ?PublicKeyToken=.*)?)$";
+        private static Regex AssemblyQualifiedNameRegex = new Regex(Pattern, RegexOptions.Compiled | RegexOptions.Singleline);
+
+        public static bool TryParse(string assemblyQualifiedName, out AssemblyName assemblyName, out string typeName)
+        {
+            assemblyName = new AssemblyName();
+            typeName = null;
+
+            var match = AssemblyQualifiedNameRegex.Match(assemblyQualifiedName);
+            if (match.Success)
+            {
+                assemblyName = new AssemblyName(match.Groups["assembly"].Value);
+                typeName = match.Groups["type"].Value;
+            }
+
+            return match.Success;
+        }
+    }
+}

--- a/tools/jmespathnet.compliance/CommandLine.cs
+++ b/tools/jmespathnet.compliance/CommandLine.cs
@@ -14,6 +14,7 @@ namespace jmespath.net.compliance
     {
         public string TestSuitesFolder { get; set; }
         public OutputFormats OutputFormat { get; set; }
+        public IList<string> Registrations { get; } = new List<string>();
 
         private CommandLine()
         {
@@ -28,6 +29,7 @@ namespace jmespath.net.compliance
             {
                 { "t|tests|test-suites=", v => commandLine.TestSuitesFolder = v },
                 { "o|output=", v => commandLine.OutputFormat = ParseOutputFormat(v) },
+                { "r|reg|register|register-functions=", v => commandLine.Registrations.Add(v) },
             };
 
             try

--- a/tools/jmespathnet.compliance/ComplianceResult.cs
+++ b/tools/jmespathnet.compliance/ComplianceResult.cs
@@ -1,12 +1,11 @@
-using System;
 using Newtonsoft.Json.Linq;
 
 namespace jmespath.net.compliance
 {
     public sealed class ComplianceResult
     {
-        public Boolean Success { get; set; }
-        public String Error { get; set; }
+        public bool Success { get; set; }
+        public string Error { get; set; }
         public JToken Result { get; set; }
     }
 }

--- a/tools/jmespathnet.compliance/ComplianceSummary.cs
+++ b/tools/jmespathnet.compliance/ComplianceSummary.cs
@@ -1,0 +1,4 @@
+﻿namespace jmespath.net.compliance
+{
+    public record ComplianceSummary(double Percent, int Succeeded, int Total, int Failed);
+}

--- a/tools/jmespathnet.compliance/Program.cs
+++ b/tools/jmespathnet.compliance/Program.cs
@@ -3,10 +3,14 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text;
+using DevLab.JmesPath.Interop;
 
 namespace jmespath.net.compliance
 {
+    using Registrations = Func<IRegisterFunctions, IRegisterFunctions>;
+
     public class Program
     {
         public static void Main(string[] args)
@@ -16,22 +20,82 @@ namespace jmespath.net.compliance
             var json = cmdLine.OutputFormat == OutputFormats.Json;
             var text = cmdLine.OutputFormat == OutputFormats.Text;
 
+            var registrations = cmdLine.Registrations;
             var folder = cmdLine.TestSuitesFolder;
 
+            var functions = GetThirdPartyRegistrations(registrations);
+
+            // run test suite
+
+            var files = EnumerateComplianceTests(folder);
+            var (compliance, complianceFuncs) = CheckCompliance(files, text, functions);
+
+            ReportComplianceResults(
+                  compliance
+                , complianceFuncs
+                , text
+                , json);
+        }
+
+        private static Registrations[] GetThirdPartyRegistrations(IList<string> registrations)
+        {
+            // a registration is a type name for a class implementing the following method:
+            // public static IRegisterFunctions Register(IRegisterFunctions repository);
+            //
+
+            Registrations[] factories =
+                    registrations
+                        .Select(LoadRegistrationFactory)
+                        .ToArray()
+                ;
+
+            return factories;
+        }
+
+        private static Registrations LoadRegistrationFactory(string assemblyQualifiedName)
+        {
+            if (!AssemblyQualifiedNameParser.TryParse(assemblyQualifiedName, out var assemblyName, out var typeName))
+                throw new Exception($"Unable to load third-party functions {assemblyQualifiedName}");
+
+            var directory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            var fileName = $"{assemblyName}.dll";
+            var path = Path.Combine(directory, fileName);
+
+            var type = Assembly
+                    .LoadFile(path)
+                    .GetType(typeName)
+                ;
+
+            var bindingFlags = BindingFlags.Public | BindingFlags.Static;
+            var method = type.GetMethod("Register", bindingFlags);
+            if (method == null)
+                throw new Exception($"Unable to load third-party functions {assemblyQualifiedName}");
+
+            Registrations func =
+                reg => method.Invoke(null, new object[] { reg, }) as IRegisterFunctions;
+
+            return func;
+        }
+
+        private static IEnumerable<string> EnumerateComplianceTests(string folder)
+        {
             var files = Enumerable.Empty<string>();
             if (Directory.Exists(folder))
                 files = Directory.EnumerateFiles(folder, "*.json");
             else if (File.Exists(folder))
                 files = new[] { folder };
+            return files;
+        }
 
-
+        private static (ComplianceSummary compliance, ComplianceSummary complianceFunctions) CheckCompliance(IEnumerable<string> files, bool logTextOut, Registrations[] functions)
+        {
             var compliance = new Compliance();
-            var functions = new Compliance();
+            var complianceFuncs = new Compliance();
 
             foreach (var path in files)
             {
                 var name = Path.GetFileName(path);
-                if (text)
+                if (logTextOut)
                 {
                     ConsoleEx.WriteLine(ConsoleColor.Cyan, $"Executing compliance test {name}...");
                 }
@@ -39,33 +103,49 @@ namespace jmespath.net.compliance
                 var content = File.ReadAllText(path, new UTF8Encoding(false));
                 if (name == "functions.json")
                 {
-                    functions.RunTestSuite(content, logTextOut: text);
+                    complianceFuncs.RunTestSuite(content, logTextOut);
                 }
                 else
                 {
-                    compliance.RunTestSuite(content, logTextOut: text);
+                    compliance.RunTestSuite(content, logTextOut, functions);
                 }
             }
 
-            var total = compliance.TestResults.Concat(functions.TestResults).Count();
-            var succeeded = compliance.TestResults.Concat(functions.TestResults).Count(r => r.Success);
+            var total = compliance.TestResults.Concat(compliance.TestResults).Count();
+            var succeeded = compliance.TestResults.Concat(compliance.TestResults).Count(r => r.Success);
             var failed = total - succeeded;
 
-            var success = (double)succeeded / total;
+            var percent = (double)succeeded / total;
 
-            if (text)
-            {
-                ConsoleEx.WriteLine(ConsoleColor.White, $"Compliance summary:");
-                ConsoleEx.WriteLine(ConsoleColor.White, $"Success rate: {success:P}, {succeeded}/{total} succeeded, {failed}/{total} failed.");
-            }
-
-            var totalFunctions = functions.TestResults.Count;
-            var succeededFunctions = functions.TestResults.Count(r => r.Success);
+            var totalFunctions = complianceFuncs.TestResults.Count;
+            var succeededFunctions = complianceFuncs.TestResults.Count(r => r.Success);
             var failedFunctions = totalFunctions - succeededFunctions;
 
-            var successFunctions = (double)succeededFunctions / totalFunctions;
+            var percentFunctions = (double)succeededFunctions / totalFunctions;
 
-            if (json)
+            return (
+                new ComplianceSummary(percent, succeeded, total, failed),
+                new ComplianceSummary(percentFunctions, succeededFunctions, totalFunctions, failedFunctions)
+                );
+        }
+
+        private static void ReportComplianceResults(
+            ComplianceSummary complianceSummary,
+            ComplianceSummary complianceSummaryFuncs,
+            bool logTextOut = true,
+            bool logJsonOut = false
+        )
+        {
+            var s = complianceSummary;
+            var f = complianceSummaryFuncs;
+
+            if (logTextOut)
+            {
+                ConsoleEx.WriteLine(ConsoleColor.White, $"Compliance summary:");
+                ConsoleEx.WriteLine(ConsoleColor.White, $"Success rate: {s.Percent:P}, {s.Succeeded}/{s.Total} succeeded, {s.Failed}/{s.Total} failed.");
+            }
+
+            if (logJsonOut)
             {
                 var serializer = new JsonSerializerSettings
                 {
@@ -74,21 +154,18 @@ namespace jmespath.net.compliance
                 };
                 var report = new ComplianceReport
                 {
-                    Compliance = 100.0 * success,
-                    FunctionSets = new []
+                    Compliance = 100.0 * s.Percent,
+                    FunctionSets = new[]
                     {
                         new FunctionSet {
                             Version = "(default)",
-                            Compliance = 100.0 * successFunctions,
+                            Compliance = 100.0 * f.Percent,
                         },
                     }
                 };
                 var output = JsonConvert.SerializeObject(report, serializer);
                 Console.WriteLine(output);
             }
-
-            var exitCode = succeeded == total ? 0 : 1;
-            Environment.Exit(exitCode);
         }
     }
 }


### PR DESCRIPTION
This commit enables third-party repositories to include this repository as a Git submodule
in order to run a compliance tool with supports for registering third-party functions.

This is necessary for the code in [this repository](https://github.com/springcomp/JmesPath.Net.Functions) to compile.