### PR TITLE
Simplify invocation of gplex/pg build tools

### DIFF
--- a/src/jmespath.net/jmespath.net.csproj
+++ b/src/jmespath.net/jmespath.net.csproj
@@ -25,13 +25,23 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
-  <Target Name="PrecompileScript" BeforeTargets="BeforeBuild" Condition=" '$(IsCrossTargetingBuild)' != 'true' ">
-    <Exec Command="dotnet make $(MSBuildProjectDirectory)/../../../bin/dotnet-gplex.dll /unicode /out:$(MSBuildProjectDirectory)/JmesPathScanner.cs $(MSBuildProjectDirectory)/JmesPathScanner.lex" />
-    <Exec Command="dotnet make $(MSBuildProjectDirectory)/../../../bin/dotnet-gppg.dll /gplex /out:$(MSBuildProjectDirectory)/JmesPathParser.cs $(MSBuildProjectDirectory)/JmesPathParser.y" />
+  <Target Name="ScannerGenerator" BeforeTargets="BeforeBuild"
+          Condition=" '$(IsCrossTargetingBuild)' != 'true' "
+          Inputs="JmesPathScanner.lex"
+          Outputs="JmesPathScanner.cs">
+    <Exec Command="dotnet gplex /unicode /out:JmesPathScanner.cs JmesPathScanner.lex" WorkingDirectory="$(MSBuildProjectDirectory)" />
+  </Target>
+
+  <Target Name="ParserGenerator" BeforeTargets="BeforeBuild"
+          Condition=" '$(IsCrossTargetingBuild)' != 'true' "
+          Inputs="JmesPathParser.y"
+          Outputs="JmesPathParser.cs">
+    <Exec Command="dotnet gppg /gplex /out:JmesPathParser.cs JmesPathParser.y" WorkingDirectory="$(MSBuildProjectDirectory)" />
   </Target>
 
   <ItemGroup>
-    <DotNetCliToolReference Include="dotnet-make" Version="1.0.30" />
+    <DotNetCliToolReference Include="StarodubOleg.GPLEX" Version="0.1.0-alpha1-5" />
+    <DotNetCliToolReference Include="StarodubOleg.GPPG" Version="0.1.0-alpha1-5" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
I had a lot of trouble building this project due to use of [dotnet-make] and how it invokes [gplex] & [gppg], assuming a relative installation directory. I'd like to suggest a simple approach that should work on anyone's machine. This PR modifies only the project file, declaring gplex & gppg as project tools. It then uses MSBuild's native capability to do [incremental building](https://docs.microsoft.com/en-us/visualstudio/msbuild/how-to-build-incrementally), which makes use of dotnet-make redundant. The invocation of gplex & gppg then becomes as simple as `dotnet gplex` and `dotnet gppg` without worrying about where they are located.


[dotnet-make]: https://www.nuget.org/packages/dotnet-make
[gplex]: https://www.nuget.org/packages/StarodubOleg.GPLEX
[gppg]: https://www.nuget.org/packages/StarodubOleg.GPPG
