### PR TITLE
Fix CS0169 warnings about unused fields in JmesPathComparison

### DIFF
--- a/src/jmespath.net/Expressions/JmesPathComparison.cs
+++ b/src/jmespath.net/Expressions/JmesPathComparison.cs
@@ -4,9 +4,6 @@ namespace DevLab.JmesPath.Expressions
 {
     public abstract class JmesPathComparison : JmesPathCompoundExpression
     {
-        private readonly JmesPathExpression left_;
-        private readonly JmesPathExpression right_;
-
         /// <summary>
         /// Initialize a new instance of the <see cref="JmesPathComparison" /> class
         /// that performs a comparison between two specified expressions.


### PR DESCRIPTION
This PR fixes Fix [CS0169] warnings about two unused fields in `JmesPathComparison`.

  [CS0169]: https://docs.microsoft.com/en-us/dotnet/csharp/misc/cs0169

Before this PR, there were 9 warnings:

```
JmesPath.cs(46,26): warning CS0618: 'JmesPath.Transform(JToken, string)' is obsolete: 'Please, use the Transform(string, string) overload instead.' [A:\JmesPath.Net.master\src\jmespath.net\jmespath.net.csproj]
Expressions\JmesPathComparison.cs(8,45): warning CS0169: The field 'JmesPathComparison.right_' is never used [A:\JmesPath.Net.master\src\jmespath.net\jmespath.net.csproj]
Expressions\JmesPathComparison.cs(7,45): warning CS0169: The field 'JmesPathComparison.left_' is never used [A:\JmesPath.Net.master\src\jmespath.net\jmespath.net.csproj]
JmesPath.cs(46,26): warning CS0618: 'JmesPath.Transform(JToken, string)' is obsolete: 'Please, use the Transform(string, string) overload instead.' [A:\JmesPath.Net.master\src\jmespath.net\jmespath.net.csproj]
Expressions\JmesPathComparison.cs(8,45): warning CS0169: The field 'JmesPathComparison.right_' is never used [A:\JmesPath.Net.master\src\jmespath.net\jmespath.net.csproj]
Expressions\JmesPathComparison.cs(7,45): warning CS0169: The field 'JmesPathComparison.left_' is never used [A:\JmesPath.Net.master\src\jmespath.net\jmespath.net.csproj]
JmesPath.cs(46,26): warning CS0618: 'JmesPath.Transform(JToken, string)' is obsolete: 'Please, use the Transform(string, string) overload instead.' [A:\JmesPath.Net.master\src\jmespath.net\jmespath.net.csproj]
Expressions\JmesPathComparison.cs(8,45): warning CS0169: The field 'JmesPathComparison.right_' is never used [A:\JmesPath.Net.master\src\jmespath.net\jmespath.net.csproj]
Expressions\JmesPathComparison.cs(7,45): warning CS0169: The field 'JmesPathComparison.left_' is never used [A:\JmesPath.Net.master\src\jmespath.net\jmespath.net.csproj]
    9 Warning(s)
    0 Error(s)
```

After applying this PR, all CS0169 warnings are gone (though 3 other CS0618 ones remain):

  [CS0618]: https://docs.microsoft.com/en-us/dotnet/csharp/misc/cs0618

```
JmesPath.cs(46,26): warning CS0618: 'JmesPath.Transform(JToken, string)' is obsolete: 'Please, use the Transform(string, string) overload instead.' [A:\JmesPath.Net.master\src\jmespath.net\jmespath.net.csproj]
JmesPath.cs(46,26): warning CS0618: 'JmesPath.Transform(JToken, string)' is obsolete: 'Please, use the Transform(string, string) overload instead.' [A:\JmesPath.Net.master\src\jmespath.net\jmespath.net.csproj]
JmesPath.cs(46,26): warning CS0618: 'JmesPath.Transform(JToken, string)' is obsolete: 'Please, use the Transform(string, string) overload instead.' [A:\JmesPath.Net.master\src\jmespath.net\jmespath.net.csproj]
    3 Warning(s)
    0 Error(s)
```
