### PR TITLE
Don't emit (private) info in generated lexer/parser

### DIFF
--- a/src/jmespath.net/JmesPathParser.cs
+++ b/src/jmespath.net/JmesPathParser.cs
@@ -2,10 +2,7 @@
 // Copyright (c) Wayne Kelly, John Gough, QUT 2005-2014
 // (see accompanying GPPGcopyright.rtf)
 
-// GPPG version 0.1.0.0
-// Machine:  DESKTOP-UQ0H65F
-// DateTime: 17/03/2017 14:35:53
-// Input file <C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y - 17/03/2017 14:35:48>
+// Input file <JmesPathParser.y - 13/06/2020 15:54:57>
 
 // options: lines gplex
 
@@ -26,7 +23,7 @@ internal enum TokenType {error=2,EOF=3,T_AND=4,T_OR=5,T_NOT=6,
     T_LPAREN=31,T_RPAREN=32,T_LISTWILDCARD=33};
 
 internal partial struct ValueType
-#line 7 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 7 "JmesPathParser.y"
         { 
        		public Token Token; 
        	}
@@ -279,7 +276,7 @@ internal partial class JmesPathParser: ShiftReduceParser<ValueType, LexLocation>
     switch (action)
     {
       case 2: // expression -> expression_impl
-#line 71 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 71 "JmesPathParser.y"
      {
 						OnExpression();
 						ResolveParsingState();
@@ -287,14 +284,14 @@ internal partial class JmesPathParser: ShiftReduceParser<ValueType, LexLocation>
 #line default
         break;
       case 19: // sub_expression -> sub_expression_impl
-#line 96 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 96 "JmesPathParser.y"
      {
 						OnSubExpression();
 					}
 #line default
         break;
       case 25: // index_expression -> expression, bracket_specifier
-#line 110 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 110 "JmesPathParser.y"
      {
 						System.Diagnostics.Debug.WriteLine("index expression (expression, bracket_specifier): {0}.", ValueStack[ValueStack.Depth-2].Token);
 						OnIndexExpression();
@@ -302,21 +299,21 @@ internal partial class JmesPathParser: ShiftReduceParser<ValueType, LexLocation>
 #line default
         break;
       case 27: // function_expression -> unquoted_string, arguments
-#line 118 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 118 "JmesPathParser.y"
      {
 						PopFunction(ValueStack[ValueStack.Depth-2].Token);
 					}
 #line default
         break;
       case 28: // arguments -> T_LPAREN, T_RPAREN
-#line 124 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 124 "JmesPathParser.y"
      {
 						PushFunction();
 					}
 #line default
         break;
       case 30: // function_arguments -> expression
-#line 131 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 131 "JmesPathParser.y"
      {
 						PushFunction();
 						AddFunctionArg();
@@ -324,7 +321,7 @@ internal partial class JmesPathParser: ShiftReduceParser<ValueType, LexLocation>
 #line default
         break;
       case 31: // function_arguments -> expression_type
-#line 136 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 136 "JmesPathParser.y"
      {
 						PushFunction();
 						AddFunctionArg();
@@ -332,35 +329,35 @@ internal partial class JmesPathParser: ShiftReduceParser<ValueType, LexLocation>
 #line default
         break;
       case 32: // function_arguments -> function_arguments, T_COMMA, expression
-#line 141 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 141 "JmesPathParser.y"
      {
 						AddFunctionArg();
 					}
 #line default
         break;
       case 33: // function_arguments -> function_arguments, T_COMMA, expression_type
-#line 145 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 145 "JmesPathParser.y"
      {
 						AddFunctionArg();
 					}
 #line default
         break;
       case 34: // current_node -> T_CURRENT
-#line 151 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 151 "JmesPathParser.y"
      {
 						OnCurrentNode();
 					}
 #line default
         break;
       case 35: // expression_type -> T_ETYPE, expression
-#line 156 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 156 "JmesPathParser.y"
      {
 						OnExpressionType();
 					}
 #line default
         break;
       case 36: // bracket_specifier -> T_LBRACKET, T_NUMBER, T_RBRACKET
-#line 162 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 162 "JmesPathParser.y"
      {
 						System.Diagnostics.Debug.WriteLine("bracket_specifier (index): {0}.", ValueStack[ValueStack.Depth-2].Token);
 						OnIndex(ValueStack[ValueStack.Depth-2].Token);
@@ -368,7 +365,7 @@ internal partial class JmesPathParser: ShiftReduceParser<ValueType, LexLocation>
 #line default
         break;
       case 37: // bracket_specifier -> T_LBRACKET, T_STAR, T_RBRACKET
-#line 167 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 167 "JmesPathParser.y"
      {
 						System.Diagnostics.Debug.WriteLine("bracket_specifier (list wildcard projection).");
 						OnListWildcardProjection();
@@ -376,14 +373,14 @@ internal partial class JmesPathParser: ShiftReduceParser<ValueType, LexLocation>
 #line default
         break;
       case 39: // bracket_specifier -> T_FILTER, expression, T_RBRACKET
-#line 173 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 173 "JmesPathParser.y"
      {
 						OnFilterProjection();
 					}
 #line default
         break;
       case 40: // bracket_specifier -> T_FLATTEN
-#line 177 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 177 "JmesPathParser.y"
      {
 						System.Diagnostics.Debug.WriteLine("bracket_specifier (flattening projection).");
 						OnFlattenProjection();
@@ -391,56 +388,56 @@ internal partial class JmesPathParser: ShiftReduceParser<ValueType, LexLocation>
 #line default
         break;
       case 41: // comparator_expression -> expression, T_EQ, expression
-#line 185 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 185 "JmesPathParser.y"
      {
 						OnComparisonExpression(ValueStack[ValueStack.Depth-2].Token);
 					}
 #line default
         break;
       case 42: // comparator_expression -> expression, T_GE, expression
-#line 189 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 189 "JmesPathParser.y"
      {
 						OnComparisonExpression(ValueStack[ValueStack.Depth-2].Token);
 					}
 #line default
         break;
       case 43: // comparator_expression -> expression, T_GT, expression
-#line 193 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 193 "JmesPathParser.y"
      {
 						OnComparisonExpression(ValueStack[ValueStack.Depth-2].Token);
 					}
 #line default
         break;
       case 44: // comparator_expression -> expression, T_LE, expression
-#line 197 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 197 "JmesPathParser.y"
      {
 						OnComparisonExpression(ValueStack[ValueStack.Depth-2].Token);
 					}
 #line default
         break;
       case 45: // comparator_expression -> expression, T_LT, expression
-#line 201 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 201 "JmesPathParser.y"
      {
 						OnComparisonExpression(ValueStack[ValueStack.Depth-2].Token);
 					}
 #line default
         break;
       case 46: // comparator_expression -> expression, T_NE, expression
-#line 205 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 205 "JmesPathParser.y"
      {
 						OnComparisonExpression(ValueStack[ValueStack.Depth-2].Token);
 					}
 #line default
         break;
       case 47: // or_expression -> expression, T_OR, expression
-#line 211 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 211 "JmesPathParser.y"
      {
 						OnOrExpression();
 					}
 #line default
         break;
       case 48: // identifier -> identifier_impl
-#line 217 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 217 "JmesPathParser.y"
      {
 						System.Diagnostics.Debug.WriteLine("identifier ({0}): {1}.", ValueStack[ValueStack.Depth-1].Token.Type, ValueStack[ValueStack.Depth-1].Token);
 						OnIdentifier(ValueStack[ValueStack.Depth-1].Token);
@@ -448,21 +445,21 @@ internal partial class JmesPathParser: ShiftReduceParser<ValueType, LexLocation>
 #line default
         break;
       case 51: // and_expression -> expression, T_AND, expression
-#line 228 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 228 "JmesPathParser.y"
      {
 						OnAndExpression();
 					}
 #line default
         break;
       case 52: // not_expression -> T_NOT, expression
-#line 234 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 234 "JmesPathParser.y"
      {
 						OnNotExpression();
 					}
 #line default
         break;
       case 54: // hash_wildcard -> T_STAR
-#line 243 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 243 "JmesPathParser.y"
      {
 						System.Diagnostics.Debug.WriteLine("wildcard (hash wildcard projection): {0}", ValueStack[ValueStack.Depth-1].Token);
 						OnHashWildcardProjection();
@@ -470,14 +467,14 @@ internal partial class JmesPathParser: ShiftReduceParser<ValueType, LexLocation>
 #line default
         break;
       case 55: // multi_select_hash -> T_LBRACE, keyval_expressions, T_RBRACE
-#line 250 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 250 "JmesPathParser.y"
      {
 						PopMultiSelectHash();
 					}
 #line default
         break;
       case 56: // keyval_expressions -> keyval_expression
-#line 255 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 255 "JmesPathParser.y"
      {
 						PushMultiSelectHash();
 						AddMultiSelectHashExpression();
@@ -485,21 +482,21 @@ internal partial class JmesPathParser: ShiftReduceParser<ValueType, LexLocation>
 #line default
         break;
       case 57: // keyval_expressions -> keyval_expressions, T_COMMA, keyval_expression
-#line 260 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 260 "JmesPathParser.y"
      {
 						AddMultiSelectHashExpression();
 					}
 #line default
         break;
       case 59: // multi_select_list -> T_LBRACKET, expressions, T_RBRACKET
-#line 270 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 270 "JmesPathParser.y"
      {
 						PopMultiSelectList();
 					}
 #line default
         break;
       case 60: // expressions -> expression
-#line 276 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 276 "JmesPathParser.y"
      {
 						PushMultiSelectList();
 						AddMultiSelectListExpression();
@@ -507,105 +504,105 @@ internal partial class JmesPathParser: ShiftReduceParser<ValueType, LexLocation>
 #line default
         break;
       case 61: // expressions -> expressions, T_COMMA, expression
-#line 281 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 281 "JmesPathParser.y"
      {
 						AddMultiSelectListExpression();
 					}
 #line default
         break;
       case 62: // pipe_expression -> expression, T_PIPE, expression
-#line 287 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 287 "JmesPathParser.y"
      {
 						OnPipeExpression();
 					}
 #line default
         break;
       case 63: // slice_expression -> T_COLON
-#line 293 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 293 "JmesPathParser.y"
      {
 						OnSliceExpression(null, null, null);
 					}
 #line default
         break;
       case 64: // slice_expression -> T_NUMBER, T_COLON
-#line 297 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 297 "JmesPathParser.y"
      {
 						OnSliceExpression(ValueStack[ValueStack.Depth-2].Token, null, null);
 					}
 #line default
         break;
       case 65: // slice_expression -> T_NUMBER, T_COLON, T_COLON
-#line 301 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 301 "JmesPathParser.y"
      {
 						OnSliceExpression(ValueStack[ValueStack.Depth-3].Token, null, null);
 					}
 #line default
         break;
       case 66: // slice_expression -> T_NUMBER, T_COLON, T_NUMBER
-#line 305 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 305 "JmesPathParser.y"
      {
 						OnSliceExpression(ValueStack[ValueStack.Depth-3].Token, ValueStack[ValueStack.Depth-1].Token, null);
 					}
 #line default
         break;
       case 67: // slice_expression -> T_NUMBER, T_COLON, T_NUMBER, T_COLON
-#line 309 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 309 "JmesPathParser.y"
      {
 						OnSliceExpression(ValueStack[ValueStack.Depth-4].Token, ValueStack[ValueStack.Depth-2].Token, null);
 					}
 #line default
         break;
       case 68: // slice_expression -> T_NUMBER, T_COLON, T_NUMBER, T_COLON, T_NUMBER
-#line 313 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 313 "JmesPathParser.y"
      {
 						OnSliceExpression(ValueStack[ValueStack.Depth-5].Token, ValueStack[ValueStack.Depth-3].Token, ValueStack[ValueStack.Depth-1].Token);
 					}
 #line default
         break;
       case 69: // slice_expression -> T_NUMBER, T_COLON, T_COLON, T_NUMBER
-#line 317 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 317 "JmesPathParser.y"
      {
 						OnSliceExpression(ValueStack[ValueStack.Depth-4].Token, null, ValueStack[ValueStack.Depth-1].Token);
 					}
 #line default
         break;
       case 70: // slice_expression -> T_COLON, T_NUMBER
-#line 321 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 321 "JmesPathParser.y"
      {
 						OnSliceExpression(null, ValueStack[ValueStack.Depth-1].Token, null);
 					}
 #line default
         break;
       case 71: // slice_expression -> T_COLON, T_NUMBER, T_COLON
-#line 325 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 325 "JmesPathParser.y"
      {
 						OnSliceExpression(null, ValueStack[ValueStack.Depth-2].Token, null);
 					}
 #line default
         break;
       case 72: // slice_expression -> T_COLON, T_NUMBER, T_COLON, T_NUMBER
-#line 329 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 329 "JmesPathParser.y"
      {
 						OnSliceExpression(null, ValueStack[ValueStack.Depth-3].Token, ValueStack[ValueStack.Depth-1].Token);
 					}
 #line default
         break;
       case 73: // slice_expression -> T_COLON, T_COLON, T_NUMBER
-#line 333 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 333 "JmesPathParser.y"
      {
 						OnSliceExpression(null, null, ValueStack[ValueStack.Depth-1].Token);
 					}
 #line default
         break;
       case 74: // slice_expression -> T_COLON, T_COLON
-#line 337 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 337 "JmesPathParser.y"
      {
 						OnSliceExpression(null, null, null);
 					}
 #line default
         break;
       case 77: // literal -> T_LSTRING
-#line 349 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 349 "JmesPathParser.y"
      {
 						System.Diagnostics.Debug.WriteLine("literal string : {0}", ValueStack[ValueStack.Depth-1].Token);
 						OnLiteralString(ValueStack[ValueStack.Depth-1].Token);
@@ -613,7 +610,7 @@ internal partial class JmesPathParser: ShiftReduceParser<ValueType, LexLocation>
 #line default
         break;
       case 78: // raw_string -> T_RSTRING
-#line 355 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 355 "JmesPathParser.y"
      {
 						System.Diagnostics.Debug.WriteLine("raw string : {0}", ValueStack[ValueStack.Depth-1].Token);
 						OnRawString(ValueStack[ValueStack.Depth-1].Token);
@@ -634,7 +631,7 @@ internal partial class JmesPathParser: ShiftReduceParser<ValueType, LexLocation>
         return CharToString((char)terminal);
   }
 
-#line 361 "C:\Projects\jmespath\jjme\src\jmespath.net/JmesPathParser.y"
+#line 361 "JmesPathParser.y"
  #line default
 }
 }

--- a/src/jmespath.net/JmesPathScanner.cs
+++ b/src/jmespath.net/JmesPathScanner.cs
@@ -5,9 +5,7 @@
 //  See accompanying file GPLEXcopyright.rtf.
 //
 //  GPLEX Version:  0.1.0.0
-//  Machine:  MOSKITOSJEREMIE
-//  DateTime: 16/03/2017 22:33:08
-//  GPLEX input file <C:\Data\GitHub\JmesPath.Net\src\jmespath.net/JmesPathScanner.lex - 16/03/2017 08:55:37>
+//  GPLEX input file <JmesPathScanner.lex - 13/06/2020 15:54:58>
 //  GPLEX frame file <embedded resource>
 //
 //  Option settings: unicode, verbose, parser, stack, minimize
@@ -369,14 +367,12 @@ int NextState() {
             SetSource(file, 0); // unicode option
         }
 
-        public JmesPathScanner(Stream file, string codepage)
-        {
+        public JmesPathScanner(Stream file, string codepage) {
             SetSource(file, CodePageHandling.GetCodePage(codepage));
-        }
-
+        }   
 #endif // !NOFILES
 
-        internal JmesPathScanner() { }
+     internal JmesPathScanner() { }
 
         private int readPos;
 

--- a/src/jmespath.net/jmespath.net.csproj
+++ b/src/jmespath.net/jmespath.net.csproj
@@ -29,14 +29,14 @@
           Condition=" '$(IsCrossTargetingBuild)' != 'true' "
           Inputs="JmesPathScanner.lex"
           Outputs="JmesPathScanner.cs">
-    <Exec Command="dotnet gplex /unicode /out:JmesPathScanner.cs JmesPathScanner.lex" WorkingDirectory="$(MSBuildProjectDirectory)" />
+    <Exec Command="dotnet gplex /unicode /noinfo /out:JmesPathScanner.cs JmesPathScanner.lex" WorkingDirectory="$(MSBuildProjectDirectory)" />
   </Target>
 
   <Target Name="ParserGenerator" BeforeTargets="BeforeBuild"
           Condition=" '$(IsCrossTargetingBuild)' != 'true' "
           Inputs="JmesPathParser.y"
           Outputs="JmesPathParser.cs">
-    <Exec Command="dotnet gppg /gplex /out:JmesPathParser.cs JmesPathParser.y" WorkingDirectory="$(MSBuildProjectDirectory)" />
+    <Exec Command="dotnet gppg /gplex /no-info /out:JmesPathParser.cs JmesPathParser.y" WorkingDirectory="$(MSBuildProjectDirectory)" />
   </Target>
 
   <ItemGroup>


### PR DESCRIPTION
This PR adds flags to `gplex` and `gppg` to prevent private information from being added as comments to the generated scanner/parser code. Not only is the information adding no value, it leaks _private_ details that are relative to the committer like his/her machine name as well as local paths in `#line` directives.