### PR TITLE
Add missing ref to parser in signed project

### DIFF
--- a/src/jmespath.net.signed/jmespath.net.signed.csproj
+++ b/src/jmespath.net.signed/jmespath.net.signed.csproj
@@ -33,4 +33,8 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Parser\JmesPath.Parser.csproj" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Unfortunately, the CI builds for PR #26 did not catch the missing reference to **JmesPath.Parser** from **jmespath.net.signed**. This PR hopes to fix the [broken build](https://ci.appveyor.com/project/jdevillard/jmespath-net/builds/34829291) on merge of PR #26 to master (74234d338ebc02afae6eb1e91706d142c22c6398).