### PR TITLE
Support integer values bigger than Int32 in min() and max() functions

### DIFF
--- a/src/jmespath.net/Functions/MaxFunction.cs
+++ b/src/jmespath.net/Functions/MaxFunction.cs
@@ -30,7 +30,7 @@ namespace DevLab.JmesPath.Functions
                             return GetMax<double>(array);
 
                         else /* if (token.Type == JTokenType.Integer) */
-                            return GetMax<int>(array);
+                            return GetMax<long>(array);
                     }
 
                 case "string":

--- a/src/jmespath.net/Functions/MinFunction.cs
+++ b/src/jmespath.net/Functions/MinFunction.cs
@@ -30,7 +30,7 @@ namespace DevLab.JmesPath.Functions
                         return GetMin<double>(array);
 
                     else /* if (token.Type == JTokenType.Integer) */
-                        return GetMin<int>(array);
+                        return GetMin<long>(array);
                 }
 
                 case "string":

--- a/tools/jmespathnet.compliance/regression/number_int64.json
+++ b/tools/jmespathnet.compliance/regression/number_int64.json
@@ -1,0 +1,17 @@
+[
+  {
+    "given": {
+      "numbers_int64": [ -9007199254740991, -1, 3, 4, 5, 9007199254740991 ]
+    },
+    "cases": [
+      {
+        "expression": "min(numbers_int64)",
+        "result": -9007199254740991
+      },
+      {
+        "expression": "max(numbers_int64)",
+        "result": 9007199254740991
+      }
+    ]
+  }
+]


### PR DESCRIPTION
The JSON number type can support integer values from [MIN_SAFE_INTEGER](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MIN_SAFE_INTEGER) to [MAX_SAFE_INTEGER](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER), which is `(-(2^53 - 1))` to `(2^53 - 1)` which require more than 32-bits to represent.

The JmesPath.Net implementation of `min()` and `max()` functions cast the number value to `int` (which is only an `Int32`) and thus does not support all possible integer values allowed by JSON.

This pull request adds support for integer values bigger than 32-bits in the `min()` and `max()` functions by casting the value to `long` (`Int64`).