### PR TITLE
Fix parsing in to_number for negative decimal numbers

### DIFF
--- a/src/jmespath.net/Functions/MathArrayFunction.cs
+++ b/src/jmespath.net/Functions/MathArrayFunction.cs
@@ -1,3 +1,8 @@
+using DevLab.JmesPath.Utils;
+using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+using System.Linq;
+
 namespace DevLab.JmesPath.Functions
 {
     public abstract class MathArrayFunction : JmesPathFunction
@@ -17,5 +22,20 @@ namespace DevLab.JmesPath.Functions
             base.Validate();
             EnsureArrayOfSame(args[0], "number", "string");
         }
+
+        public override JToken Execute(params JmesPathFunctionArgument[] args)
+        {
+            var array = (JArray) args[0].Token;
+
+            if (array.Count == 0)
+                return JTokens.Null;
+
+            var item = array[0];
+            var dataTypes = array.Select(t => t.GetTokenType()).Distinct();
+
+            return Execute(array, dataTypes);
+        }
+
+        protected abstract JToken Execute(JArray array, IEnumerable<string> dataTypes);
     }
 }

--- a/src/jmespath.net/Functions/MaxFunction.cs
+++ b/src/jmespath.net/Functions/MaxFunction.cs
@@ -1,48 +1,16 @@
-using System;
 using System.Linq;
-using DevLab.JmesPath.Utils;
 using Newtonsoft.Json.Linq;
 
 namespace DevLab.JmesPath.Functions
 {
-    public class MaxFunction : MathArrayFunction
+    public class MaxFunction : MinOrMaxFunction
     {
         public MaxFunction()
-            : base("max", 1)
+            : base("max")
         {
         }
 
-        public override JToken Execute(params JmesPathFunctionArgument[] args)
-        {
-            var array = (JArray)args[0].Token;
-
-            if (array.Count == 0)
-                return JTokens.Null;
-
-            var item = array[0];
-            var type = item.GetTokenType();
-
-            switch (type)
-            {
-                case "number":
-                    {
-                        if (item.Type == JTokenType.Float)
-                            return GetMax<double>(array);
-
-                        else /* if (token.Type == JTokenType.Integer) */
-                            return GetMax<long>(array);
-                    }
-
-                case "string":
-                    return GetMax<string>(array);
-
-                default:
-                    System.Diagnostics.Debug.Assert(false);
-                    throw new NotSupportedException("Error: invalid-type");
-            }
-        }
-
-        private static JToken GetMax<T>(JArray array)
+        protected override JToken GetMinOrMax<T>(JArray array)
         {
             var sequence = array
                 .Select(u => u.Value<T>())

--- a/src/jmespath.net/Functions/MinFunction.cs
+++ b/src/jmespath.net/Functions/MinFunction.cs
@@ -1,48 +1,16 @@
-using System;
 using System.Linq;
-using DevLab.JmesPath.Utils;
 using Newtonsoft.Json.Linq;
 
 namespace DevLab.JmesPath.Functions
 {
-    public class MinFunction : MathArrayFunction
+    public class MinFunction : MinOrMaxFunction
     {
         public MinFunction()
-            : base("min", 1)
+            : base("min")
         {
         }
 
-        public override JToken Execute(params JmesPathFunctionArgument[] args)
-        {
-            var array = (JArray) args[0].Token;
-
-            if (array.Count == 0)
-                return JTokens.Null;
-
-            var item = array[0];
-            var type = item.GetTokenType();
-
-            switch (type)
-            {
-                case "number":
-                {
-                    if (item.Type == JTokenType.Float)
-                        return GetMin<double>(array);
-
-                    else /* if (token.Type == JTokenType.Integer) */
-                        return GetMin<long>(array);
-                }
-
-                case "string":
-                    return GetMin<string>(array);
-
-                default:
-                    System.Diagnostics.Debug.Assert(false);
-                    throw new NotSupportedException("Error: invalid-type");
-            }
-        }
-
-        private static JToken GetMin<T>(JArray array)
+        protected override JToken GetMinOrMax<T>(JArray array)
         {
             var sequence = array
                 .Select(u => u.Value<T>())

--- a/src/jmespath.net/Functions/MinOrMaxFunction.cs
+++ b/src/jmespath.net/Functions/MinOrMaxFunction.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using DevLab.JmesPath.Utils;
+using Newtonsoft.Json.Linq;
+
+namespace DevLab.JmesPath.Functions
+{
+    public abstract class MinOrMaxFunction : MathArrayFunction
+    {
+        public MinOrMaxFunction(string name)
+            : base(name, 1)
+        { }
+
+        protected override JToken Execute(JArray array, IEnumerable<string> dataTypes)
+        {
+            var item = array[0];
+            var type = item.GetTokenType();
+
+            switch (type)
+            {
+                case "number":
+                    {
+                        // special case if all items in the array are integers
+
+                        var tokenTypes = array.Select(x => x.Type).Distinct().ToArray();
+                        if (tokenTypes.Length == 1)
+                        {
+                            if (tokenTypes[0] == JTokenType.Integer)
+                                return GetMinOrMax<long>(array);
+                        }
+
+                        return GetMinOrMax<double>(array);
+                    }
+
+                case "string":
+                    return GetMinOrMax<string>(array);
+
+                default:
+                    System.Diagnostics.Debug.Assert(false);
+                    throw new NotSupportedException("Error: invalid-type");
+            }
+        }
+
+        protected abstract JToken GetMinOrMax<T>(JArray array);
+    }
+}

--- a/src/jmespath.net/Functions/ToNumberFunction.cs
+++ b/src/jmespath.net/Functions/ToNumberFunction.cs
@@ -34,7 +34,7 @@ namespace DevLab.JmesPath.Functions
 
                         if (Int64.TryParse(value, out i))
                             return new JValue(i);
-                        if (double.TryParse(value, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out d))
+                        if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out d))
                             return new JValue(d);
 
                         return JTokens.Null;

--- a/tests/jmespathnet.tests/Functions/ToNumberFunctionTest.cs
+++ b/tests/jmespathnet.tests/Functions/ToNumberFunctionTest.cs
@@ -1,0 +1,52 @@
+﻿using jmespath.net.tests.Parser;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace jmespath.net.tests.Functions
+{
+    using FactAttribute = Xunit.FactAttribute;
+
+    public class ToNumberFunctionTest : ParserTestBase
+    {
+        [Fact]
+        public void ToNumberPositive()
+        {
+            const string json = "{\"foo\": \"1234\"}";
+            const string expression = "to_number(foo)";
+            const string expected = "1234";
+
+            Assert(expression, json, expected);
+        }
+
+        [Fact]
+        public void ToNumberNegative()
+        {
+            const string json = "{\"foo\": \"-1234\"}";
+            const string expression = "to_number(foo)";
+            const string expected = "-1234";
+
+            Assert(expression, json, expected);
+        }
+
+        [Fact]
+        public void ToNumberDecimalPositive()
+        {
+            const string json = "{\"foo\": \"1234.5\"}";
+            const string expression = "to_number(foo)";
+            const string expected = "1234.5";
+
+            Assert(expression, json, expected);
+        }
+
+        [Fact]
+        public void ToNumberDecimalNegative()
+        {
+            const string json = "{\"foo\": \"-1234.5\"}";
+            const string expression = "to_number(foo)";
+            const string expected = "-1234.5";
+
+            Assert(expression, json, expected);
+        }
+    }
+}

--- a/tools/jmespathnet.compliance/regression/number_float.json
+++ b/tools/jmespathnet.compliance/regression/number_float.json
@@ -1,0 +1,17 @@
+[
+  {
+    "given": {
+      "numbers_float": [ -12345, -12345.67, -1234e56, 0e-18, 0.1233, 0.123E+45 ]
+    },
+    "cases": [
+      {
+        "expression": "min(numbers_float)",
+        "result": -1.234e59
+      },
+      {
+        "expression": "max(numbers_float)",
+        "result": 1.23e44
+      }
+    ]
+  }
+]


### PR DESCRIPTION
The current implementation of the `to_number` built-in function doesn't work with negative decimal numbers. This pull request fixes that bug and adds unit tests to verify the fix.

When parsing decimal numbers, I changed the number style to `Float` because that seems to be the best option for complying with the `number` type in the JSON specification:

- it allows leading and trailing whitespace;
- it allows a leading sign;
- it allows an exponent.

Question for maintainer: I noticed that when integers are parsed the code uses the more forgiving `Int64.TryParse()` method that doesn't require you to specify a number style or culture. Is there a reason parsing decimal numbers uses the overload that requires you to specify a number style and culture? Should it be changed to the more general `Double.TryParse()` overload?