### PR TITLE
Feature/compliance report

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,8 +50,9 @@ build_script:
   - ps: C:\projects\jmespath-net\bin\update-version.ps1 -Version $Env:APPVEYOR_BUILD_VERSION
   - ps: dotnet build "src\jmespath.net" /p:BuildInParallel=false -c %CONFIGURATION% --version-suffix $Env:LABEL
   - ps: |
-      dotnet run --project tools\jmespathnet.compliance\ -- -t tools\jmespathnet.compliance\jmespath.test\tests
       dotnet run --project tools\jmespathnet.compliance\ -- -t tools\jmespathnet.compliance\regression
+      dotnet run --project tools\jmespathnet.compliance\ -- -t tools\jmespathnet.compliance\jmespath.test\tests
+      dotnet run --project tools\jmespathnet.compliance\ -- -t tools\jmespathnet.compliance\jmespath.test\tests -o json >compliance-2016-09-05-9e8d0e3.json
 
 after_build:
   - dotnet pack "src\jmespath.net.parser" -c %CONFIGURATION%

--- a/tools/jmespathnet.compliance/CommandLine.cs
+++ b/tools/jmespathnet.compliance/CommandLine.cs
@@ -4,12 +4,20 @@ using NDesk.Options;
 
 namespace jmespath.net.compliance
 {
+    public enum OutputFormats
+    {
+        Text,
+        Json,
+    }
+
     public class CommandLine
     {
         public string TestSuitesFolder { get; set; }
+        public OutputFormats OutputFormat { get; set; }
 
         private CommandLine()
         {
+            OutputFormat = OutputFormats.Text;
         }
 
         public static CommandLine Parse(string[] args)
@@ -19,6 +27,7 @@ namespace jmespath.net.compliance
             var options = new OptionSet
             {
                 { "t|tests|test-suites=", v => commandLine.TestSuitesFolder = v },
+                { "o|output=", v => commandLine.OutputFormat = ParseOutputFormat(v) },
             };
 
             try
@@ -33,6 +42,15 @@ namespace jmespath.net.compliance
             }
 
             return commandLine;
+        }
+
+        private static OutputFormats ParseOutputFormat(string v)
+        {
+            var outputFormat = OutputFormats.Text;
+            if (Enum.TryParse<OutputFormats>(v, true, out var _outputFormat))
+                outputFormat = _outputFormat;
+
+            return outputFormat;
         }
 
         private static void ParseRemainingArguments(List<string> remaining)

--- a/tools/jmespathnet.compliance/Compliance.cs
+++ b/tools/jmespathnet.compliance/Compliance.cs
@@ -18,7 +18,7 @@ namespace jmespath.net.compliance
 
         public List<ComplianceResult> TestResults { get; private set; }
 
-        public void RunTestSuite(string input)
+        public void RunTestSuite(string input, bool logTextOut = false)
         {
             var json = JToken.Parse(input);
             var testsuites = json as JArray;
@@ -50,15 +50,18 @@ namespace jmespath.net.compliance
 
                     var expected = testcase["result"];
 
-                    var result = RunTestCase(document, expression, expected, error);
+                    var result = RunTestCase(document, expression, expected, error, logTextOut);
                     TestResults.Add(result);
                 }
             }
         }
 
-        private static ComplianceResult RunTestCase(JToken document, string expression, JToken expected, string error)
+        private static ComplianceResult RunTestCase(JToken document, string expression, JToken expected, string error, bool logTextOut = false)
         {
-            ConsoleEx.Out.Write(ConsoleColor.Gray, $"{expression}...");
+            if (logTextOut)
+            {
+                ConsoleEx.Out.Write(ConsoleColor.Gray, $"{expression}...");
+            }
 
             var result = EvaluateExpression(document, expression);
 
@@ -102,8 +105,11 @@ namespace jmespath.net.compliance
                 }
             }
 
-            ConsoleEx.Out.Write(color, message.ToString());
-            ConsoleEx.Out.WriteLine(ConsoleColor.Gray, ".");
+            if (logTextOut)
+            {
+                ConsoleEx.Out.Write(color, message.ToString());
+                ConsoleEx.Out.WriteLine(ConsoleColor.Gray, ".");
+            }
 
             return result;
         }

--- a/tools/jmespathnet.compliance/ComplianceReport.cs
+++ b/tools/jmespathnet.compliance/ComplianceReport.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace jmespath.net.compliance
+{
+    public sealed class ComplianceReport
+    {
+        [JsonProperty("compliance")]
+        public double Compliance { get; set; }
+
+        [JsonProperty("functionSets")]
+        public FunctionSet[] FunctionSets { get; set; }
+    }
+
+    public sealed class FunctionSet {
+
+        [JsonProperty("version")]
+        public string Version { get; set; }
+        [JsonProperty("compliance")]
+        public double Compliance { get; set; }
+    }
+}

--- a/tools/jmespathnet.compliance/Program.cs
+++ b/tools/jmespathnet.compliance/Program.cs
@@ -1,8 +1,9 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace jmespath.net.compliance
 {
@@ -12,32 +13,79 @@ namespace jmespath.net.compliance
         {
             var cmdLine = CommandLine.Parse(args);
 
+            var json = cmdLine.OutputFormat == OutputFormats.Json;
+            var text = cmdLine.OutputFormat == OutputFormats.Text;
+
             var folder = cmdLine.TestSuitesFolder;
+
             var files = Enumerable.Empty<string>();
             if (Directory.Exists(folder))
                 files = Directory.EnumerateFiles(folder, "*.json");
             else if (File.Exists(folder))
                 files = new[] { folder };
 
+
             var compliance = new Compliance();
+            var functions = new Compliance();
 
             foreach (var path in files)
             {
                 var name = Path.GetFileName(path);
-                ConsoleEx.WriteLine(ConsoleColor.Cyan, $"Executing compliance test {name}...");
+                if (text)
+                {
+                    ConsoleEx.WriteLine(ConsoleColor.Cyan, $"Executing compliance test {name}...");
+                }
 
                 var content = File.ReadAllText(path, new UTF8Encoding(false));
-                compliance.RunTestSuite(content);
+                if (name == "functions.json")
+                {
+                    functions.RunTestSuite(content, logTextOut: text);
+                }
+                else
+                {
+                    compliance.RunTestSuite(content, logTextOut: text);
+                }
             }
 
-            var total = compliance.TestResults.Count;
-            var succeeded = compliance.TestResults.Count(r => r.Success);
+            var total = compliance.TestResults.Concat(functions.TestResults).Count();
+            var succeeded = compliance.TestResults.Concat(functions.TestResults).Count(r => r.Success);
             var failed = total - succeeded;
 
             var success = (double)succeeded / total;
 
-            ConsoleEx.WriteLine(ConsoleColor.White, $"Compliance summary:");
-            ConsoleEx.WriteLine(ConsoleColor.White, $"Success rate: {success:P}, {succeeded}/{total} succeeded, {failed}/{total} failed.");
+            if (text)
+            {
+                ConsoleEx.WriteLine(ConsoleColor.White, $"Compliance summary:");
+                ConsoleEx.WriteLine(ConsoleColor.White, $"Success rate: {success:P}, {succeeded}/{total} succeeded, {failed}/{total} failed.");
+            }
+
+            var totalFunctions = functions.TestResults.Count;
+            var succeededFunctions = functions.TestResults.Count(r => r.Success);
+            var failedFunctions = totalFunctions - succeededFunctions;
+
+            var successFunctions = (double)succeededFunctions / totalFunctions;
+
+            if (json)
+            {
+                var serializer = new JsonSerializerSettings
+                {
+                    Formatting = Formatting.None,
+                    NullValueHandling = NullValueHandling.Ignore,
+                };
+                var report = new ComplianceReport
+                {
+                    Compliance = 100.0 * success,
+                    FunctionSets = new []
+                    {
+                        new FunctionSet {
+                            Version = "(default)",
+                            Compliance = 100.0 * successFunctions,
+                        },
+                    }
+                };
+                var output = JsonConvert.SerializeObject(report, serializer);
+                Console.WriteLine(output);
+            }
 
             var exitCode = succeeded == total ? 0 : 1;
             Environment.Exit(exitCode);


### PR DESCRIPTION
This PR adds a `-o | --output  [text|json]` to the `jmespathnet.compliance` command-line tool.
This outputs compliance summary report with the following format:

```pwsh
dotnet run --project tools\jmespathnet.compliance\ -- -t .\tools\jmespathnet.compliance\jmespath.test\tests -o json
```
```json
{"compliance":100.0,"functionSets":[{"version":"(default)","compliance":100.0}]}
```