### PR TITLE
#43 - changed proper casing for JMESPath.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # JmesPath.Net
-A fully compliant implementation of [JMESPATH](http://jmespath.org/specification.html) for .Net Core.
+A fully compliant implementation of [JMESPath](http://jmespath.org/specification.html) for .Net Core.
 
 [![Build status](https://ci.appveyor.com/api/projects/status/va3p48ufrj0pxl1t/branch/master?svg=true)](https://ci.appveyor.com/project/jdevillard/jmespath-net/branch/master)
  


### PR DESCRIPTION
This PR updates the casing of `JMESPath` in the `README.md`.
Please, consider also changing the GitHub description on the right:

![image](https://user-images.githubusercontent.com/8488398/155837625-2dbee395-983d-435f-a445-cd24bb05a902.png)
