### PR TITLE
Fix incorrect encoding when producing compliance report.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,7 +52,10 @@ build_script:
   - ps: |
       dotnet run --project tools\jmespathnet.compliance\ -- -t tools\jmespathnet.compliance\regression
       dotnet run --project tools\jmespathnet.compliance\ -- -t tools\jmespathnet.compliance\jmespath.test\tests
-      dotnet run --project tools\jmespathnet.compliance\ -- -t tools\jmespathnet.compliance\jmespath.test\tests -o json >compliance-2016-09-05-9e8d0e3.json
+      Set-Content `
+        -Path compliance-2016-09-05-9e8d0e3.json
+        -Value ( dotnet run --project tools\jmespathnet.compliance\ -- -t tools\jmespathnet.compliance\jmespath.test\tests -o json ) `
+        -Encoding UTF8
 
 after_build:
   - dotnet pack "src\jmespath.net.parser" -c %CONFIGURATION%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,7 +53,7 @@ build_script:
       dotnet run --project tools\jmespathnet.compliance\ -- -t tools\jmespathnet.compliance\regression
       dotnet run --project tools\jmespathnet.compliance\ -- -t tools\jmespathnet.compliance\jmespath.test\tests
       Set-Content `
-        -Path compliance-2016-09-05-9e8d0e3.json
+        -Path compliance-2016-09-05-9e8d0e3.json `
         -Value ( dotnet run --project tools\jmespathnet.compliance\ -- -t tools\jmespathnet.compliance\jmespath.test\tests -o json ) `
         -Encoding UTF8
 


### PR DESCRIPTION
The CI produced a compliance file encoded in UTF16-LE instead of UTF-8.
This PR fixes the encoding of the compliance file.