### PR TITLE
Fixed incorrect reference to unofficial compliance test submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tools/jmespathnet.compliance/jmespath.test"]
+	path = tools/jmespathnet.compliance/jmespath.test
+	url = https://github.com/jmespath-community/jmespath.test.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "tools/jmespathnet.compliance/jmespath.test"]
-	path = tools/jmespathnet.compliance/jmespath.test
-	url = https://github.com/jmespath-unofficial/jmespath.test.git


### PR DESCRIPTION
The compliance tests are run from the JMESPath Community compliance test fork repository.
This PR updates the reference – pointing to the repository named _unofficial_ – to the new repository named _community_ instead.