### PR TITLE
Renamed `to_object` function to `from_items`.

### DIFF
--- a/src/jmespath.net/Functions/FromItemsFunction.cs
+++ b/src/jmespath.net/Functions/FromItemsFunction.cs
@@ -5,10 +5,10 @@ using Newtonsoft.Json.Linq;
 
 namespace DevLab.JmesPath.Functions
 {
-    public class ToObjectFunction : JmesPathFunction
+    public class FromItemsFunction : JmesPathFunction
     {
-        public ToObjectFunction()
-            : base("to_object", 1)
+        public FromItemsFunction()
+            : base("from_items", 1)
         {
         }
 

--- a/tools/jmespathnet.compliance/Compliance.cs
+++ b/tools/jmespathnet.compliance/Compliance.cs
@@ -131,8 +131,8 @@ namespace jmespath.net.compliance
 
                 parser.FunctionRepository
                     .Register<ItemsFunction>()
+                    .Register<FromItemsFunction>()
                     .Register<LetFunction>()
-                    .Register<ToObjectFunction>()
                     .Register<ZipFunction>()
                     ;
 


### PR DESCRIPTION
Implements the [Object Manipulation Functions](https://github.com/jmespath-community/jmespath.spec/discussions/47#discussioncomment-3308897) proposal.

This PR renames the `to_object()` custom function to the `from_items()` proposed name.