### PR TITLE
Pipe expression remembered to handle `null` values.

### DIFF
--- a/src/jmespath.net/Expressions/JmesPathPipeExpression.cs
+++ b/src/jmespath.net/Expressions/JmesPathPipeExpression.cs
@@ -29,7 +29,7 @@ namespace DevLab.JmesPath.Expressions
                 .AsJToken()
                 ;
 
-            return JTokens.IsNull(token) ? token : Right.Transform(token);
+            return Right.Transform(token);
         }
 
         public override string ToString()


### PR DESCRIPTION
#77 was introduce to align the behaviour of `pipe-expression` to that of `sub-expression` when handling `null` values on their left-hand-side.

However, it seems more desirable to keep the original behaviour which can be summarized like the pseudocode:

## Sub-Expression

```
left-evaluation = search(left-expression, original-json-document)
if left-evaluation is `null` then result = `null`
else result = search(right-expression, left-evaluation)
```

## Pipe-Expression

```
left-evaluation = search(left-expression, original-json-document)
result = search(right-expression, left-evaluation)
```

## Summary

This PR re-introduces support for `pipe-expression` to still evaluate the right-hand-side expression when the left-hand-side evaluates to `null`.