### PR TITLE
JEP-18 Grouping

### DIFF
--- a/src/jmespath.net/Functions/GroupByFunction.cs
+++ b/src/jmespath.net/Functions/GroupByFunction.cs
@@ -1,0 +1,67 @@
+﻿using DevLab.JmesPath.Utils;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DevLab.JmesPath.Functions
+{
+    public class GroupByFunction : ByFunction
+    {
+        public GroupByFunction()
+            : base("group_by")
+        {
+        }
+
+        public override void Validate(params JmesPathFunctionArgument[] args)
+        {
+            base.Validate(args);
+
+            System.Diagnostics.Debug.Assert(args.Length == 2);
+            System.Diagnostics.Debug.Assert(args[0].IsToken);
+            System.Diagnostics.Debug.Assert(args[1].IsExpressionType);
+
+            var array = (JArray)args[0].Token;
+            if (array.Any(i => i.Type != JTokenType.Object))
+                throw new Exception($"Error: invalid-type, function {Name} expects its first argument to be an array of objects.");
+        }
+        public override JToken Execute(params JmesPathFunctionArgument[] args)
+        {
+            System.Diagnostics.Debug.Assert(args.Length == 2);
+            System.Diagnostics.Debug.Assert(args[0].IsToken);
+            System.Diagnostics.Debug.Assert(args[1].IsExpressionType);
+
+            var array = (JArray)args[0].Token;
+            var expression = args[1].Expression;
+
+            var dictionary = new Dictionary<string, IList<JToken>>();
+
+            foreach (var element in array)
+            {
+                string key = "";
+
+                var token = expression.Transform(element).AsJToken();
+                if (token != JTokens.Null)
+                {
+                    if (token.GetTokenType() != "string")
+                        continue;
+
+                    key = token.Value<string>();
+                    AddElement(dictionary, key, element);
+                }
+            }
+
+            var properties = dictionary.Select(kvp => new JProperty(kvp.Key, kvp.Value));
+
+            return new JObject(properties);
+        }
+
+        private static void AddElement(IDictionary<string, IList<JToken>> dictionary, string key, JToken element)
+        {
+            if (!dictionary.ContainsKey(key))
+                dictionary[key] = new List<JToken>();
+
+            dictionary[key].Add(element);
+        }
+    }
+}

--- a/src/jmespath.net/Functions/GroupByFunction.cs
+++ b/src/jmespath.net/Functions/GroupByFunction.cs
@@ -43,8 +43,9 @@ namespace DevLab.JmesPath.Functions
                 var token = expression.Transform(element).AsJToken();
                 if (token != JTokens.Null)
                 {
-                    if (token.GetTokenType() != "string")
-                        continue;
+                    var tokenType = token.GetTokenType();
+                    if (tokenType != "string")
+                        throw new Exception($"Error: invalid-type, function {Name} expects its second expression-type argument to evaluate to a 'string' value but received '{tokenType}' {token} instead.");
 
                     key = token.Value<string>();
                     AddElement(dictionary, key, element);

--- a/src/jmespath.net/Functions/JmesPathFunctionFactory.cs
+++ b/src/jmespath.net/Functions/JmesPathFunctionFactory.cs
@@ -29,6 +29,7 @@ namespace DevLab.JmesPath.Functions
                 .Register<FindFirstFunction>()
                 .Register<FindLastFunction>()
                 .Register<FloorFunction>()
+                .Register<GroupByFunction>()
                 .Register<JoinFunction>()
                 .Register<LengthFunction>()
                 .Register<LowerFunction>()

--- a/tools/jmespathnet.compliance/regression/group_by_function.json
+++ b/tools/jmespathnet.compliance/regression/group_by_function.json
@@ -10,50 +10,8 @@
     },
     "cases": [
       {
-        "expression": "group_by(@, &`false`)",
-        "error":  "invalid-type"
-      },
-      {
-        "expression": "group_by(keys(items[*].spec|[0]), &`false`)",
-        "error":  "invalid-type"
-      },
-      {
-        "expression": "group_by(items, spec.nodeName)",
-        "error":  "invalid-type"
-      },
-      {
-        "expression": "group_by(items, &spec.nodeName)",
-        "result": {
-          "node_01": [
-            { "spec": { "nodeNumber":  1, "nodeName": "node_01", "other": "values_01" } },
-            { "spec": { "nodeNumber":  1, "nodeName": "node_01", "other": "values_04" } }
-          ],
-          "node_02": [
-            { "spec": { "nodeNumber":  2, "nodeName": "node_02", "other": "values_02" } }
-          ],
-          "node_03": [
-            { "spec": { "nodeNumber":  3, "nodeName": "node_03", "other": "values_03" } }
-          ]
-        }
-      },
-      {
-        "expression": "group_by(items, &to_string(spec.nodeNumber))",
-        "result": {
-          "1": [
-            { "spec": { "nodeNumber":  1, "nodeName": "node_01", "other": "values_01" } },
-            { "spec": { "nodeNumber":  1, "nodeName": "node_01", "other": "values_04" } }
-          ],
-          "2": [
-            { "spec": { "nodeNumber":  2, "nodeName": "node_02", "other": "values_02" } }
-          ],
-          "3": [
-            { "spec": { "nodeNumber":  3, "nodeName": "node_03", "other": "values_03" } }
-          ]
-        }
-      },
-      {
         "expression": "group_by(items, &spec.nodeNumber)",
-        "result": {}
+        "error": "invalid-type"
       }
     ]
   }

--- a/tools/jmespathnet.compliance/regression/group_by_function.json
+++ b/tools/jmespathnet.compliance/regression/group_by_function.json
@@ -1,0 +1,60 @@
+[
+  {
+    "given": {
+      "items": [
+        { "spec": { "nodeNumber":  1, "nodeName": "node_01", "other": "values_01" } },
+        { "spec": { "nodeNumber":  2, "nodeName": "node_02", "other": "values_02" } },
+        { "spec": { "nodeNumber":  3, "nodeName": "node_03", "other": "values_03" } },
+        { "spec": { "nodeNumber":  1, "nodeName": "node_01", "other": "values_04" } }
+      ]
+    },
+    "cases": [
+      {
+        "expression": "group_by(@, &`false`)",
+        "error":  "invalid-type"
+      },
+      {
+        "expression": "group_by(keys(items[*].spec|[0]), &`false`)",
+        "error":  "invalid-type"
+      },
+      {
+        "expression": "group_by(items, spec.nodeName)",
+        "error":  "invalid-type"
+      },
+      {
+        "expression": "group_by(items, &spec.nodeName)",
+        "result": {
+          "node_01": [
+            { "spec": { "nodeNumber":  1, "nodeName": "node_01", "other": "values_01" } },
+            { "spec": { "nodeNumber":  1, "nodeName": "node_01", "other": "values_04" } }
+          ],
+          "node_02": [
+            { "spec": { "nodeNumber":  2, "nodeName": "node_02", "other": "values_02" } }
+          ],
+          "node_03": [
+            { "spec": { "nodeNumber":  3, "nodeName": "node_03", "other": "values_03" } }
+          ]
+        }
+      },
+      {
+        "expression": "group_by(items, &to_string(spec.nodeNumber))",
+        "result": {
+          "1": [
+            { "spec": { "nodeNumber":  1, "nodeName": "node_01", "other": "values_01" } },
+            { "spec": { "nodeNumber":  1, "nodeName": "node_01", "other": "values_04" } }
+          ],
+          "2": [
+            { "spec": { "nodeNumber":  2, "nodeName": "node_02", "other": "values_02" } }
+          ],
+          "3": [
+            { "spec": { "nodeNumber":  3, "nodeName": "node_03", "other": "values_03" } }
+          ]
+        }
+      },
+      {
+        "expression": "group_by(items, &spec.nodeNumber)",
+        "result": {}
+      }
+    ]
+  }
+]


### PR DESCRIPTION
# group_by function

|||
|---|---
| **JEP**    |  18
| **Author** | Maxime Labelle
| **Created**| 05-August-2022
| **SemVer** | MINOR
| **Status**| Draft

## Abstract

This JEP introduces a new `group_by()` function.

## Specification

### group_by

```
object group_by(array[object] $elements, expression->string) $expr)
```

Groups an array of objects `$elements` using an expression `$expr` as the group key.
The `$expr` expression is applied to each element in the array `$elements` and the 
resulting value is used as a group key.

The result is an object whose keys are the unique set of string keys and whose respective values are an array of objects array matching the group criteria.

Objects that do not match the group criteria are discarded from the output.
This includes objects for which applying the `$expr` expression evaluates to `null`.

If the result of applying the `$expr` expression against the current array element
results in type other than `string` or `null`, a type error MUST be raised.

### Examples

Given the following input JSON document:

```json
{
  "items": [
    { "spec": { "nodeName": "node_01", "other": "values_01" } },
    { "spec": { "nodeName": "node_02", "other": "values_02" } },
    { "spec": { "nodeName": "node_03", "other": "values_03" } },
    { "spec": { "nodeName": "node_01", "other": "values_04" } }
  ]
}
```

Example:

|Expression|Result
|---|---
|`` group_by(items, &spec.nodeName) ``| ` {"node_01": [{"spec": {"nodeName": "node_01", "other": "values_01"}}, {"spec": {"nodeName": "node_01", "other": "values_04"}}], "node_02": [{"spec": {"nodeName": "node_02", "other": "values_02"}}], "node_03": [{"spec": {"nodeName": "node_03", "other": "values_03"}}]} `

Given the following input JSON document:

```json
{
  "array": [
    { "name": "one", "b": true },
    { "name": "two", "b": false },
    { "b": false }
  ]
}
```

Here are a couple of other examples:

|Expression|Result
|---|---
|`` group_by(array, &name) `` | ` {"one":[{"name":"one","b":true}],"two":[{"name":"two","b":false}]} `
|`` group_by(array, &b) `` | `invalid-type`
