### PR TITLE
Fix JMESPath merge function null handling (#107)

### DIFF
--- a/src/jmespath.net/Functions/MergeFunction.cs
+++ b/src/jmespath.net/Functions/MergeFunction.cs
@@ -18,11 +18,15 @@ namespace DevLab.JmesPath.Functions
         public override JToken Execute(params JmesPathFunctionArgument[] args)
         {
             var result = new JObject();
+            var jsonMergeSettings = new JsonMergeSettings
+            {
+                MergeNullValueHandling = MergeNullValueHandling.Merge
+            };
 
             foreach (var argument in args)
             {
                 var token = (JObject)argument.Token;
-                result.Merge(token);
+                result.Merge(token, jsonMergeSettings);
             }
 
             return result;

--- a/tests/jmespathnet.tests/Functions/MergeFunctionTest.cs
+++ b/tests/jmespathnet.tests/Functions/MergeFunctionTest.cs
@@ -1,0 +1,48 @@
+using jmespath.net.tests.Expressions;
+using jmespath.net.tests.Parser;
+using Newtonsoft.Json.Linq;
+
+namespace jmespath.net.tests.Functions
+{
+    using FactAttribute = Xunit.FactAttribute;
+
+    public class MergeFunctionTest : ParserTestBase
+    {
+        [Fact]
+        public void MergeOverwriteValue()
+        {
+            const string json = "{\"bar\":2}";
+            const string expression = "merge(@, { bar: `3` } )";
+            const string expected = "{\"bar\":3}";
+
+            Assert(expression, json, expected);
+        }
+
+        [Fact]
+        public void MergeNewValue() {
+            const string json = "{\"bar\":2}";
+            const string expression = "merge(@, { foo: `3` } )";
+            const string expected = "{\"bar\":2,\"foo\":3}";
+
+            Assert(expression, json, expected);
+        }
+
+        [Fact]
+        public void MergeNewNullValue() {
+            const string json = "{\"bar\":2}";
+            const string expression = "merge(@, { foo: `null` } )";
+            const string expected = "{\"bar\":2,\"foo\":null}";
+
+            Assert(expression, json, expected);
+        }
+
+        [Fact]
+        public void MergeOverwriteWithNull() {
+            const string json = "{\"bar\":2}";
+            const string expression = "merge(@, { bar: `null` } )";
+            const string expected = "{\"bar\":null}";
+
+            Assert(expression, json, expected);
+        }
+    }
+}


### PR DESCRIPTION
* Added tests for `merge` function